### PR TITLE
added libpkcs11-helper to make the app start again

### DIFF
--- a/net.codeindustry.MasterPDFEditor.yaml
+++ b/net.codeindustry.MasterPDFEditor.yaml
@@ -19,6 +19,12 @@ modules:
       - echo 127.0.0.1 > /app/etc/sane.d/net.conf
       - echo net > /app/etc/sane.d/dll.conf
 
+  - name: libpkcs11-helper
+    sources:
+      - type: archive
+        url: https://github.com/OpenSC/pkcs11-helper/releases/download/pkcs11-helper-1.29.0/pkcs11-helper-1.29.0.tar.bz2
+        sha256: 996846a3c8395e03d8c0515111dc84d82e6e3648d44ba28cb2dbbbca2d4db7d6
+
   - name: masterpdfeditor5
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
It complains when started:
/app/bin/masterpdfeditor5: error while loading shared libraries: libpkcs11-helper.so.1: cannot open shared object file: No such file or directory