### PR TITLE
add support for aarch64

### DIFF
--- a/net.codeindustry.MasterPDFEditor.yaml
+++ b/net.codeindustry.MasterPDFEditor.yaml
@@ -40,12 +40,24 @@ modules:
         url: https://code-industry.net/public/master-pdf-editor-5.9.82-qt5.x86_64.tar.gz
         filename: master-pdf-editor.tar.gz
         sha256: 09bae18502748a25f3f21509122fbfc5bd9919bba7b8fb882209824602613555
+        only-arches: [x86_64]
         size: 80442378
         x-checker-data:
           type: html
           url: https://code-industry.net/free-pdf-editor/
           version-pattern: master-pdf-editor-([0-9.]+)-qt5\.x86_64\.tar\.gz
           url-template: https://code-industry.net/public/master-pdf-editor-$version-qt5.x86_64.tar.gz
+      - type: extra-data
+        url: https://code-industry.net/public/master-pdf-editor-5.9.81-qt5.arm64.tar.gz
+        filename: master-pdf-editor.tar.gz
+        sha256: 4c537fb1b8a2a1b7590c34bc7de920a958aad1d8e5d647484864b0b25c3f34d7
+        only-arches: [aarch64]
+        size: 67505570
+        x-checker-data:
+          type: html
+          url: https://code-industry.net/free-pdf-editor/
+          version-pattern: master-pdf-editor-([0-9.]+)-qt5\.arm64\.tar\.gz
+          url-template: https://code-industry.net/public/master-pdf-editor-$version-qt5.arm64.tar.gz
       - type: script
         dest-filename: apply_extra.sh
         commands:


### PR DESCRIPTION
This PR adds support for aarch64 architecture. 
Right now, flathub claims compatibility with aarch64, despite the builder only loading the x86_64 version of masterpdfeditor.
Adding architecture specific download links is sufficient enough to get the software running on aarch64.

Unfortunately the last released aarch64 version is a bit behind.

fixes #67 